### PR TITLE
Update train_crop.py

### DIFF
--- a/data/io/DOTA/train_crop.py
+++ b/data/io/DOTA/train_crop.py
@@ -131,7 +131,7 @@ def format_label(txt_list):
     format_data = []
     for i in txt_list[2:]:
         format_data.append(
-        [int(xy) for xy in i.split(' ')[:8]] + [class_list.index(i.split(' ')[8])]
+        [int(float(xy)) for xy in i.split(' ')[:8]] + [class_list.index(i.split(' ')[8])]
         # {'x0': int(i.split(' ')[0]),
         # 'x1': int(i.split(' ')[2]),
         # 'x2': int(i.split(' ')[4]),


### PR DESCRIPTION
Modify:
int(xy) --> int(float(xy))

Solving this issue:
Traceback (most recent call last):                                                                                                                                        File "data/io/DOTA/train_crop.py", line 244, in <module>                                                                                                                  box = format_label(txt_data)                                                                                                                                          File "data/io/DOTA/train_crop.py", line 136, in format_label                                                                                                              [int(xy) for xy in i.split(' ')[:8]] + [class_list.index(i.split(' ')[8])]                                                                                            File "data/io/DOTA/train_crop.py", line 136, in <listcomp>                                                                                                                [int(xy) for xy in i.split(' ')[:8]] + [class_list.index(i.split(' ')[8])]                                                                                          ValueError: invalid literal for int() with base 10: '1786.0'